### PR TITLE
fix: make result Send + Sync

### DIFF
--- a/src/client_internals/errors.rs
+++ b/src/client_internals/errors.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use thiserror::Error;
 
 /// Wrapper `Result` type
-pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 /// Errors that can be thrown
 #[derive(Debug, Error)]


### PR DESCRIPTION
This changes:
- Changes `Result<T>` to be `Send + Sync` so multithreaded runtimes can use them.