### PR TITLE
refactor: expose underlying errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/jenkins_api"
 keywords = ["jenkins"]
 license = "MIT"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 url = "2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jenkins_api"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["François Mockers <mockersf@gmail.com>"]
 description = "Bindings for the Jenkins JSON API"
 repository = "https://github.com/mockersf/jenkins-api.rs"

--- a/src/client.rs
+++ b/src/client.rs
@@ -76,23 +76,23 @@ impl<'a> From<Path<'a>> for PrivatePath<'a> {
         match value {
             Path::Home => PrivatePath::Home,
             Path::View { name } => PrivatePath::View {
-                name: Name::Name(name),
+                name: Name::UrlEncodedName(name),
             },
             Path::Job {
                 name,
                 configuration,
             } => PrivatePath::Job {
-                name: Name::Name(name),
-                configuration: configuration.map(Name::Name),
+                name: Name::UrlEncodedName(name),
+                configuration: configuration.map(Name::UrlEncodedName),
             },
             Path::Build {
                 job_name,
                 number,
                 configuration,
             } => PrivatePath::Build {
-                job_name: Name::Name(job_name),
+                job_name: Name::UrlEncodedName(job_name),
                 number,
-                configuration: configuration.map(Name::Name),
+                configuration: configuration.map(Name::UrlEncodedName),
             },
             Path::Queue => PrivatePath::Queue,
             Path::QueueItem { id } => PrivatePath::QueueItem { id },
@@ -101,13 +101,13 @@ impl<'a> From<Path<'a>> for PrivatePath<'a> {
                 number,
                 configuration,
             } => PrivatePath::MavenArtifactRecord {
-                job_name: Name::Name(job_name),
+                job_name: Name::UrlEncodedName(job_name),
                 number,
-                configuration: configuration.map(Name::Name),
+                configuration: configuration.map(Name::UrlEncodedName),
             },
             Path::Computers => PrivatePath::Computers,
             Path::Computer { name } => PrivatePath::Computer {
-                name: Name::Name(name),
+                name: Name::UrlEncodedName(name),
             },
             Path::Raw { path } => PrivatePath::Raw { path },
         }

--- a/src/client_internals/csrf.rs
+++ b/src/client_internals/csrf.rs
@@ -1,8 +1,7 @@
 use reqwest::{header::HeaderName, header::HeaderValue, RequestBuilder};
 use serde::Deserialize;
 
-use super::{path::Path, Jenkins};
-use crate::client::Result;
+use super::{errors::CrumbError, path::Path, Jenkins};
 
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -15,20 +14,26 @@ impl Jenkins {
     pub(crate) async fn add_csrf_to_request(
         &self,
         request_builder: RequestBuilder,
-    ) -> Result<RequestBuilder> {
+    ) -> Result<RequestBuilder, CrumbError> {
         if self.csrf_enabled {
             let crumb = self.get_csrf().await?;
             Ok(request_builder.header(
-                HeaderName::from_lowercase(crumb.crumb_request_field.to_lowercase().as_bytes())?,
-                HeaderValue::from_str(&crumb.crumb)?,
+                HeaderName::from_lowercase(crumb.crumb_request_field.to_lowercase().as_bytes())
+                    .map_err(CrumbError::InvalidName)?,
+                HeaderValue::from_str(&crumb.crumb).map_err(CrumbError::InvalidValue)?,
             ))
         } else {
             Ok(request_builder)
         }
     }
 
-    pub(crate) async fn get_csrf(&self) -> Result<Crumb> {
-        let crumb: Crumb = self.get(&Path::CrumbIssuer).await?.json().await?;
+    pub(crate) async fn get_csrf(&self) -> Result<Crumb, CrumbError> {
+        let crumb: Crumb = self
+            .get(&Path::CrumbIssuer)
+            .await?
+            .json()
+            .await
+            .map_err(CrumbError::Http)?;
         Ok(crumb)
     }
 }

--- a/src/client_internals/path.rs
+++ b/src/client_internals/path.rs
@@ -12,7 +12,7 @@ pub enum Name<'a> {
     UrlEncodedName(&'a str),
 }
 
-impl<'a> Display for Name<'a> {
+impl Display for Name<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
             Name::Name(name) => write!(f, "{}", urlencoding::encode(name)),
@@ -91,7 +91,7 @@ pub enum Path<'a> {
     },
     CrumbIssuer,
 }
-impl<'a> Display for Path<'a> {
+impl Display for Path<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
             Path::Home => Ok(()),

--- a/src/client_internals/path.rs
+++ b/src/client_internals/path.rs
@@ -230,7 +230,7 @@ impl Jenkins {
                 } else {
                     Path::Job {
                         name: Name::UrlEncodedName(&path[5..slashes[2]]),
-                        configuration: Some(Name::Name(last_part)),
+                        configuration: Some(Name::UrlEncodedName(last_part)),
                     }
                 }
             }
@@ -254,7 +254,9 @@ impl Jenkins {
                         number: build::BuildNumber::Number(
                             path[(slashes[3] + 1)..(path.len() - 1)].parse().unwrap(),
                         ),
-                        configuration: Some(Name::Name(&path[(slashes[2] + 1)..slashes[3]])),
+                        configuration: Some(Name::UrlEncodedName(
+                            &path[(slashes[2] + 1)..slashes[3]],
+                        )),
                     }
                 }
             }
@@ -270,7 +272,9 @@ impl Jenkins {
                         number: build::BuildNumber::Number(
                             path[(slashes[3] + 1)..slashes[4]].parse().unwrap(),
                         ),
-                        configuration: Some(Name::Name(&path[(slashes[2] + 1)..slashes[3]])),
+                        configuration: Some(Name::UrlEncodedName(
+                            &path[(slashes[2] + 1)..slashes[3]],
+                        )),
                     }
                 }
             }
@@ -279,22 +283,26 @@ impl Jenkins {
             },
             ("/job", 0..4) => Path::Job {
                 name: Name::UrlEncodedName(&path[5..slashes[2]]),
-                configuration: Some(Name::Name(&path[slashes[2] + 1..path.len() - 1])),
+                configuration: None,
             },
             ("/job", n) => {
                 if &path[slashes[n - 4]..slashes[n - 3]] == "/job" {
                     if let Ok(build_number) = path[(slashes[n - 2] + 1)..slashes[n - 1]].parse() {
                         return Path::Build {
-                            job_name: Name::Name(&path[5..slashes[2]]),
+                            job_name: Name::UrlEncodedName(&path[5..slashes[2]]),
                             number: build::BuildNumber::Number(build_number),
-                            configuration: Some(Name::Name(&path[slashes[2] + 1..slashes[n - 2]])),
+                            configuration: Some(Name::UrlEncodedName(
+                                &path[slashes[2] + 1..slashes[n - 2]],
+                            )),
                         };
                     }
                 }
 
                 Path::Job {
                     name: Name::UrlEncodedName(&path[5..slashes[2]]),
-                    configuration: Some(Name::Name(&path[slashes[2] + 1..path.len() - 1])),
+                    configuration: Some(Name::UrlEncodedName(
+                        &path[slashes[2] + 1..path.len() - 1],
+                    )),
                 }
             }
             (_, _) => Path::Raw { path },

--- a/src/client_internals/path.rs
+++ b/src/client_internals/path.rs
@@ -230,7 +230,7 @@ impl Jenkins {
                 } else {
                     Path::Job {
                         name: Name::UrlEncodedName(&path[5..slashes[2]]),
-                        configuration: Some(Name::UrlEncodedName(last_part)),
+                        configuration: Some(Name::Name(last_part)),
                     }
                 }
             }
@@ -254,9 +254,7 @@ impl Jenkins {
                         number: build::BuildNumber::Number(
                             path[(slashes[3] + 1)..(path.len() - 1)].parse().unwrap(),
                         ),
-                        configuration: Some(Name::UrlEncodedName(
-                            &path[(slashes[2] + 1)..slashes[3]],
-                        )),
+                        configuration: Some(Name::Name(&path[(slashes[2] + 1)..slashes[3]])),
                     }
                 }
             }
@@ -272,9 +270,7 @@ impl Jenkins {
                         number: build::BuildNumber::Number(
                             path[(slashes[3] + 1)..slashes[4]].parse().unwrap(),
                         ),
-                        configuration: Some(Name::UrlEncodedName(
-                            &path[(slashes[2] + 1)..slashes[3]],
-                        )),
+                        configuration: Some(Name::Name(&path[(slashes[2] + 1)..slashes[3]])),
                     }
                 }
             }
@@ -282,23 +278,23 @@ impl Jenkins {
                 id: path[(slashes[2] + 1)..(path.len() - 1)].parse().unwrap(),
             },
             ("/job", 0..4) => Path::Job {
-                name: Name::UrlEncodedName(&path[5..(path.len() - 1)]),
-                configuration: None,
+                name: Name::UrlEncodedName(&path[5..slashes[2]]),
+                configuration: Some(Name::Name(&path[slashes[2] + 1..path.len() - 1])),
             },
             ("/job", n) => {
                 if &path[slashes[n - 4]..slashes[n - 3]] == "/job" {
                     if let Ok(build_number) = path[(slashes[n - 2] + 1)..slashes[n - 1]].parse() {
                         return Path::Build {
-                            job_name: Name::UrlEncodedName(&path[5..slashes[n - 2]]),
+                            job_name: Name::Name(&path[5..slashes[2]]),
                             number: build::BuildNumber::Number(build_number),
-                            configuration: None,
+                            configuration: Some(Name::Name(&path[slashes[2] + 1..slashes[n - 2]])),
                         };
                     }
                 }
 
                 Path::Job {
-                    name: Name::UrlEncodedName(&path[5..(path.len() - 1)]),
-                    configuration: None,
+                    name: Name::UrlEncodedName(&path[5..slashes[2]]),
+                    configuration: Some(Name::Name(&path[slashes[2] + 1..path.len() - 1])),
                 }
             }
             (_, _) => Path::Raw { path },

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -20,7 +20,6 @@ macro_rules! specialize {
     ($common:ty => $trait:path) => {
         impl $common {
             #[doc = "Read the object as one of it's specialization implementing $trait"]
-            #[allow(unused_qualifications)]
             pub fn as_variant<T>(&self) -> std::result::Result<T, serde_json::Error>
             where
                 T: Class + $trait,

--- a/src/nodes/mod.rs
+++ b/src/nodes/mod.rs
@@ -2,8 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::client_internals::{Name, Path, Result};
-use crate::Jenkins;
+use crate::client_internals::{Name, Path};
+use crate::{
+    client_internals::{ClientError, RequestError},
+    Jenkins,
+};
 
 pub mod computer;
 pub mod monitor;
@@ -25,13 +28,22 @@ pub struct ComputerSet {
 
 impl Jenkins {
     /// Get a `ComputerSet`
-    pub async fn get_nodes(&self) -> Result<ComputerSet> {
-        let response = self.get(&Path::Computers).await?.json().await?;
+    pub async fn get_nodes(&self) -> Result<ComputerSet, ClientError> {
+        let response = self
+            .get(&Path::Computers)
+            .await
+            .map_err(|e| ClientError::Request(RequestError::Http(e)))?
+            .json()
+            .await
+            .map_err(|e| ClientError::Request(RequestError::Http(e)))?;
         Ok(response)
     }
 
     /// Get a `Computer`
-    pub async fn get_node<'a, C>(&self, computer_name: C) -> Result<computer::CommonComputer>
+    pub async fn get_node<'a, C>(
+        &self,
+        computer_name: C,
+    ) -> Result<computer::CommonComputer, ClientError>
     where
         C: Into<computer::ComputerName<'a>>,
     {
@@ -39,21 +51,25 @@ impl Jenkins {
             .get(&Path::Computer {
                 name: Name::Name(computer_name.into().0),
             })
-            .await?
+            .await
+            .map_err(|e| ClientError::Request(RequestError::Http(e)))?
             .json()
-            .await?;
+            .await
+            .map_err(|e| ClientError::Request(RequestError::Http(e)))?;
         Ok(response)
     }
 
     /// Get the master `Computer`
-    pub async fn get_master_node(&self) -> Result<computer::MasterComputer> {
+    pub async fn get_master_node(&self) -> Result<computer::MasterComputer, ClientError> {
         let response = self
             .get(&Path::Computer {
                 name: Name::Name("(master)"),
             })
-            .await?
+            .await
+            .map_err(|e| ClientError::Request(RequestError::Http(e)))?
             .json()
-            .await?;
+            .await
+            .map_err(|e| ClientError::Request(RequestError::Http(e)))?;
         Ok(response)
     }
 }


### PR DESCRIPTION
This changes:
- Exposes underlying http errors, removes `Box<dyn std::error::Error + Send + Sync>`
- Bumps crate edition -> 2021